### PR TITLE
patch support for missing lit element hydration script

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,10 @@
   "engines": {
     "node": ">=18.0.0"
   },
-  "packageManager": "pnpm@10.5.2+sha256.79a98daa90248b50815e31460790f118c56fe099113370826caa0153be6daba5"
+  "packageManager": "pnpm@10.5.2+sha256.79a98daa90248b50815e31460790f118c56fe099113370826caa0153be6daba5",
+  "pnpm": {
+    "patchedDependencies": {
+      "@greenwood/plugin-renderer-lit": "patches/@greenwood__plugin-renderer-lit.patch"
+    }
+  }
 }

--- a/patches/@greenwood__plugin-renderer-lit.patch
+++ b/patches/@greenwood__plugin-renderer-lit.patch
@@ -1,0 +1,17 @@
+diff --git a/src/index.js b/src/index.js
+index 20e1b849d04173dbed6417d379edd4a17caa23ca..c69e9424c1884ab23157c0a9118dd4d505564bcf 100755
+--- a/src/index.js
++++ b/src/index.js
+@@ -7,9 +7,9 @@ class LitHydrationResource extends ResourceInterface {
+ 
+   async shouldIntercept(url) {
+     const { pathname } = url;
+-    const matchingRoute = this.compilation.graph.find((node) => node.route === pathname) || {};
+-
+-    return matchingRoute.isSSR && matchingRoute.hydration;
++    const matchingRoute = this.compilation.graph.find((node) => node.route === pathname);
++  
++    return matchingRoute && ((matchingRoute.isSSR && matchingRoute.hydration) || this.compilation.config.prerender);
+   }
+ 
+   async intercept(url, request, response) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@greenwood/plugin-renderer-lit':
+    hash: sjocr7cet2zwymanjgeay364jm
+    path: patches/@greenwood__plugin-renderer-lit.patch
+
 importers:
 
   .:
@@ -29,7 +34,7 @@ importers:
         version: 0.31.1
       '@greenwood/plugin-renderer-lit':
         specifier: ^0.31.1
-        version: 0.31.1(@greenwood/cli@0.31.1)(lit@3.2.1)
+        version: 0.31.1(patch_hash=sjocr7cet2zwymanjgeay364jm)(@greenwood/cli@0.31.1)(lit@3.2.1)
       '@greenwood/plugin-typescript':
         specifier: ^0.31.1
         version: 0.31.1(@greenwood/cli@0.31.1)
@@ -3189,7 +3194,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@greenwood/plugin-renderer-lit@0.31.1(@greenwood/cli@0.31.1)(lit@3.2.1)':
+  '@greenwood/plugin-renderer-lit@0.31.1(patch_hash=sjocr7cet2zwymanjgeay364jm)(@greenwood/cli@0.31.1)(lit@3.2.1)':
     dependencies:
       '@greenwood/cli': 0.31.1
       '@lit-labs/ssr': 3.3.1


### PR DESCRIPTION
From [our discussion](https://github.com/ProjectEvergreen/greenwood/discussions/1434#discussioncomment-12418163), here is Initial patch support to fix https://github.com/ProjectEvergreen/greenwood/issues/1435 from our
![Screenshot 2025-03-06 at 2 36 15 PM](https://github.com/user-attachments/assets/585b36bc-0865-4a51-ba01-6dffed6a5a59)

However, I am seeing a SSR template mismatch error FYI
![Screenshot 2025-03-06 at 1 53 02 PM](https://github.com/user-attachments/assets/7bcd5146-814a-4ded-9c89-ef7a38ba68c3)