### PR TITLE
have Vite raw import plugin handle any raw import types (including CSS)

### DIFF
--- a/src/vite/raw-plugin.ts
+++ b/src/vite/raw-plugin.ts
@@ -38,7 +38,7 @@ export function transformRawImports(): Plugin {
         const filename = id.slice(0, id.indexOf(`.type${hint}`));
         const contents = await fs.readFile(filename, "utf-8");
 
-        /* eslint-enable @typescript-eslint/no-non-null-assertion */
+        /* eslint-disable @typescript-eslint/no-non-null-assertion */
         const response = await rawResource.intercept!(
           null!,
           null!,

--- a/src/vite/raw-plugin.ts
+++ b/src/vite/raw-plugin.ts
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
+import path from 'path';
 // 1) import the greenwood plugin and lifecycle helpers
-import type { Compilation } from "@greenwood/cli";
+import type { Compilation, Resource } from "@greenwood/cli";
 import { readAndMergeConfig } from "@greenwood/cli/src/lifecycles/config.js";
 import { initContext } from "@greenwood/cli/src/lifecycles/context.js";
 import { greenwoodPluginImportRaw } from "@greenwood/plugin-import-raw";
@@ -15,25 +16,30 @@ const compilation: Compilation = {
 };
 
 // 3) initialize the plugin
-const rawResource = greenwoodPluginImportRaw()[0].provider(compilation);
+const rawResource: Resource = greenwoodPluginImportRaw()[0].provider(compilation);
 
 // 4) customize Vite
 export function transformRawImports(): Plugin {
+  const hint = "?type=raw";
+
   return {
     name: "transform-raw-imports",
     enforce: "pre",
+    // @ts-expect-error have to reconcile this vite config type-check
+    resolveId: (id: string, importer: string) => {
+      if (
+        id.endsWith(hint)
+      ) {
+        // add .type so Raw imports are not precessed by Vite's default pipeline
+        return path.join(path.dirname(importer), `${id.slice(0, id.indexOf(hint))}.type${hint}`);
+      }
+    },
     load: async (id) => {
-      if (id.endsWith("?type=raw")) {
-        const filename = id.slice(0, -9);
+      if (id.endsWith(hint)) {
+        const filename = id.slice(0, id.indexOf(`.type${hint}`));
         const contents = await fs.readFile(filename, "utf-8");
-
-        /* eslint-disable @typescript-eslint/no-non-null-assertion */
-        const response = await rawResource.intercept!(
-          null!,
-          null!,
-          new Response(contents),
-        );
-        /* eslint-enable @typescript-eslint/no-non-null-assertion */
+        // @ts-expect-error Greenwood should allow all resource lifecycle args to be optional
+        const response = await rawResource.intercept(new URL(`file://${filename}`), null, new Response(contents));
         const body = await response.text();
 
         return body;

--- a/src/vite/raw-plugin.ts
+++ b/src/vite/raw-plugin.ts
@@ -44,6 +44,7 @@ export function transformRawImports(): Plugin {
           null!,
           new Response(contents),
         );
+        /* eslint-enable @typescript-eslint/no-non-null-assertion */
         const body = await response.text();
 
         return body;


### PR DESCRIPTION
So the main issue was that Vite has its own default pipeline for handling CSS files, so this change has the raw intercept loader suffix all eligible file paths (including _.css) with a _.type_ to ensure Vite doesn't try and do its default behavior of trying to extra CSS files to `<style>` tags.

![Screenshot 2025-03-12 at 9 09 14 PM](https://github.com/user-attachments/assets/017c5d70-ceb5-474d-bd19-c119d9f36e73)

----


I opened [an issue to update the docs](https://github.com/ProjectEvergreen/www.greenwoodjs.dev/issues/192) with this more general purpose approach.  Thanks for helping to catch this!